### PR TITLE
[WIP] OrSpecification implementation

### DIFF
--- a/src/Computaria/Sphecific/OrSpecification.php
+++ b/src/Computaria/Sphecific/OrSpecification.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Computaria\Sphecific;
+
+class OrSpecification implements SpecificationInterface
+{
+    private $leftOperand = null;
+    private $rightOperand = null;
+
+    public function __construct(SpecificationInterface $leftOperand, SpecificationInterface $rightOperand)
+    {
+        $this->leftOperand = $leftOperand;
+        $this->rightOperand = $rightOperand;
+    }
+
+    public function isSatisfiedBy($object)
+    {
+        return ($this->leftOperand->isSatisfiedBy($object) || $this->rightOperand->isSatisfiedBy($object));
+    }
+
+    public function whyWasNotSatisfied()
+    {
+        return $this->leftOperand->whyWasNotSatisfied() . " and " . $this->rightOperand->whyWasNotSatisfied();
+    }
+}

--- a/tests/Computaria/Sphecific/OrSpecificationTest.php
+++ b/tests/Computaria/Sphecific/OrSpecificationTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Computaria\Sphecific;
+
+class OrSpecficationTest extends \PHPUnit_Framework_TestCase
+{
+    private $onlyObjectsSpecification = null;
+    private $sizeSpecification = null;
+
+    protected function setUp()
+    {
+        $this->onlyObjectsSpecification = new \Test\Stub\OnlyObjectsSpecification;
+        $this->sizeSpecification = new \Test\Stub\MinimumArraySizeSpecification;
+    }
+
+    protected function tearDown()
+    {
+        $this->composite = null;
+        $this->onlyObjectsSpecification = null;
+    }
+
+    public function testIsSatisfiedWhenBothOperandsAreSatisfied()
+    {
+        $orSpecification = new OrSpecification($this->onlyObjectsSpecification, $this->sizeSpecification);
+
+        $arrayObject = new \ArrayObject(array(1, 2));
+
+        $this->assertTrue($orSpecification->isSatisfiedBy($arrayObject));
+    }
+
+    public function testIsSatisfiedWhenOneOperandsIsNotSatisfied()
+    {
+        $orSpecification = new OrSpecification($this->onlyObjectsSpecification, $this->sizeSpecification);
+
+        $arrayObject = new \ArrayObject(array(1));
+
+        $this->assertTrue($orSpecification->isSatisfiedBy($arrayObject));
+    }
+
+    public function testIsNotSatisfiedWhenBothOperandsAreNotSatisfied()
+    {
+        $orSpecification = new OrSpecification($this->onlyObjectsSpecification, $this->sizeSpecification);
+
+        $arrayObject = array();
+
+        $this->assertFalse($orSpecification->isSatisfiedBy($arrayObject));
+    }
+}


### PR DESCRIPTION
I don't think that this stubs are good examples... And there some things that I would do to be sure that all parameters are objects but this is another PR.

By doing this is possible to use `OrSpecification` along with `CompositeSpecification` and the other implementations of: `AndSpecification` and `NotSpecification` are really, really easy to do :)
